### PR TITLE
Add quotes around the confPath and serviceName in the command line

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -451,7 +451,7 @@ static int startRedis(void) {
 
     g_redisProcess = NULL;
 
-    sds commandLine = sdscatprintf(sdsempty(), "%s %s", g_serviceName, g_redisConfPath);
+    sds commandLine = sdscatprintf(sdsempty(), "\"%s\" \"%s\"", g_serviceName, g_redisConfPath);
 
     LOG_INFO("Starting Redis with command line: %s", commandLine);
 


### PR DESCRIPTION
In the case where either the service name, or conf path have spaces in them (e.g. "C:\Program Files...") they need to be quoted before passing them on the command line to redis-server.exe. Otherwise redis-server.exe sees them as multiple arguments, causing it to print the usage information and quit.
