### PR TITLE
Added obsolescence message to README

### DIFF
--- a/README
+++ b/README
@@ -1,8 +1,8 @@
-Download the binaries from:
+OBSOLETE
+--------
 
-  http://ruilopes.com/redis-setup/
+This Windows port is only up to Redis 2.4.6. There have been a number of major improvements to Redis since that version. Other projects such as **[MSOpenTech/redis](https://github.com/MSOpenTech/redis)** provide Windows releases of more recent versions of Redis. 
 
-------
 
 About this fork
 ---------------
@@ -45,6 +45,10 @@ It is made to be as close as possible to original unix version.
 You can download prebuilt binaries here: 
 
    http://github.com/dmajkic/redis/downloads
+
+or here:
+
+   http://ruilopes.com/redis-setup/
 
 Building Redis on Windows
 -------------------------

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 OBSOLETE
 --------
 
-This Windows port is only up to Redis 2.4.6. There have been a number of major improvements to Redis since that version. Other projects such as **[MSOpenTech/redis](https://github.com/MSOpenTech/redis)** provide Windows releases of more recent versions of Redis. 
+This Windows port is only up to Redis 2.4.6. There have been a number of major improvements to Redis since that version. Other projects such as MSOpenTech/redis (https://github.com/MSOpenTech/redis) provide Windows releases of more recent versions of Redis. 
 
 
 About this fork


### PR DESCRIPTION
This project appears in search results and is linked to by a number of different sources which may lead some users to think that this is the most recent Windows release of Redis available. The notice can always be removed if the project is restarted. 
